### PR TITLE
fix: do not set unexpected config values

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,5 @@ spring:
           content:
             enabled: true
             paths: /**/*.js,/**/*.css,/**/*.svg,/**/*.jpeg
-app:
-  isGenomDeTestSubmission: true
 server:
   forward-headers-strategy: framework


### PR DESCRIPTION
In `application.yml` only default values or values referencing `app.*` values should be present. No unexpected fix values for specific customer related purposes should be set here.